### PR TITLE
Fixes for examples; Left/Right and Planck 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,30 @@
+---
+BasedOnStyle: Google
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: 'true'
+AlignConsecutiveDeclarations: 'true'
+AlignOperands: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: 'false'
+BinPackArguments: 'true'
+BinPackParameters: 'true'
+ColumnLimit: '1000'
+IndentCaseLabels: 'true'
+IndentPPDirectives: AfterHash
+IndentWidth: '4'
+MaxEmptyLinesToKeep: '1'
+PointerAlignment: Right
+SortIncludes: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: 'false'
+SpacesBeforeTrailingComments: 1
+TabWidth: '4'
+UseTab: Never
+
+...

--- a/examples/LeftSplit/LeftSplit.ino
+++ b/examples/LeftSplit/LeftSplit.ino
@@ -11,25 +11,23 @@
 #define LK_1 LK
 #define LK_2 LK
 
-
 KEYS(leftKeys) = LAYOUT(
-                   PW_0  ,  ____  , KC_ESC , KC_F1  ,  KC_F2 ,  KC_F3 ,  KC_F4 ,  KC_F5 , KC_F6  ,
-                   PW_1  ,  ____  , KC_GRV ,  KC_1  ,  KC_2  ,  KC_3  ,  KC_4  ,  KC_5  , KC_DEL ,
-                   PW_2  ,  ____  , KC_TAB ,  KC_Q  ,  KC_W  ,  KC_F  ,  KC_P  ,  KC_G  , KC_BSPC,
-                   PW_3  ,  ____  , ST_SFT ,  KC_A  ,  KC_R  ,  KC_S  ,  KC_T  ,  KC_D  , KC_ENT ,
-                   PW_4  ,  ____  , ST_CTL ,  KC_Z  ,  KC_X  ,  KC_C  ,  KC_V  ,  KC_B  ,  LK_1  ,
-                   ____  ,  ____  ,  ____  ,  PW_6  ,  ____  ,  ST_ALT,  ____  ,  ST_GUI,  ____
-                 );
+  PW_0  ,  ____  , KC_ESC , KC_F1  ,  KC_F2 ,  KC_F3 ,  KC_F4 ,  KC_F5 , KC_F6  ,
+  PW_1  ,  ____  , KC_GRV ,  KC_1  ,  KC_2  ,  KC_3  ,  KC_4  ,  KC_5  , KC_DEL ,
+  PW_2  ,  ____  , KC_TAB ,  KC_Q  ,  KC_W  ,  KC_F  ,  KC_P  ,  KC_G  , KC_BSPC,
+  PW_3  ,  ____  , ST_SFT ,  KC_A  ,  KC_R  ,  KC_S  ,  KC_T  ,  KC_D  , KC_ENT ,
+  PW_4  ,  ____  , ST_CTL ,  KC_Z  ,  KC_X  ,  KC_C  ,  KC_V  ,  KC_B  ,  LK_1  ,
+  ____  ,  ____  ,  ____  ,  PW_6  ,  ____  ,  ST_ALT,  ____  ,  ST_GUI,  ____
+);
 
 KEYS(rightKeys) = LAYOUT(
-                    KC_F7 , KC_F8  , KC_F9  ,  KC_F10, KC_F11 , KC_F12 , MD_VOLD, MD_PLAY, MD_VOLU ,
-                    KC_DEL,  KC_6  ,  KC_7  ,  KC_8  , KC_9   ,  KC_0  , KC_MINS, KC_EQL , PW_5    ,
-                    KC_BSPC,  KC_J  ,  KC_L  ,  KC_U  , KC_Y   , KC_SCLN , KC_LBRC, KC_RBRC, KC_PGUP ,
-                    KC_ENT,  KC_H  ,  KC_N  ,  KC_E  , KC_I   ,  KC_O  , KC_QUOT,  ST_SFT, KC_PGDN ,
-                    LK_2  ,  KC_K  ,  KC_M  , KC_COMM , KC_DOT , KC_SLSH , KC_BSLS,  KC_UP , ST_HYP  ,
-                    ____  , KC_SPC ,  ____  ,  ____  , ____   ,  ____  , KC_LEFT, KC_DOWN, KC_RGHT
-                  );
-
+  KC_F7 , KC_F8  , KC_F9  ,  KC_F10, KC_F11 , KC_F12 , MD_VOLD, MD_PLAY, MD_VOLU ,
+  KC_DEL,  KC_6  ,  KC_7  ,  KC_8  , KC_9   ,  KC_0  , KC_MINS, KC_EQL , PW_5    ,
+  KC_BSPC,  KC_J  ,  KC_L  ,  KC_U  , KC_Y   , KC_SCLN , KC_LBRC, KC_RBRC, KC_PGUP ,
+  KC_ENT,  KC_H  ,  KC_N  ,  KC_E  , KC_I   ,  KC_O  , KC_QUOT,  ST_SFT, KC_PGDN ,
+  LK_2  ,  KC_K  ,  KC_M  , KC_COMM , KC_DOT , KC_SLSH , KC_BSLS,  KC_UP , ST_HYP  ,
+  ____  , KC_SPC ,  ____  ,  ____  , ____   ,  ____  , KC_LEFT, KC_DOWN, KC_RGHT
+);
 
 Scanner scanner = Scanner(leftKeys, pinRows, pinCols, ROWS, COLS);
 Mechy mechy = Mechy();

--- a/examples/LeftSplit/LeftSplit.ino
+++ b/examples/LeftSplit/LeftSplit.ino
@@ -8,31 +8,27 @@
 #include <Mechy/Receiver.h>
 #include <Mechy/Hardware/BFO9000.h>
 
-#define DATA _D1
-#define CLK _D0
+#define LK_1 LK
+#define LK_2 LK
 
-#define ROWS 6
-#define COLS 9
-const uint8_t pinRows[] = { _D3, _D2, _D4, _C6, _D7, _E6};
-const uint8_t pinCols[] = { _B5, _B6, _B2, _B3, _B1, _F7, _F6, _F5, _F4};
 
 KEYS(leftKeys) = LAYOUT(
-    PW_0  ,  ____  , KC_ESC , KC_F1  ,  KC_F2 ,  KC_F3 ,  KC_F4 ,  KC_F5 , KC_F6  ,
-    PW_1  ,  ____  , KC_GRV ,  KC_1  ,  KC_2  ,  KC_3  ,  KC_4  ,  KC_5  , KC_DEL ,
-    PW_2  ,  ____  , KC_TAB ,  KC_Q  ,  KC_W  ,  KC_F  ,  KC_P  ,  KC_G  , KC_BSPC,
-    PW_3  ,  ____  , ST_SFT ,  KC_A  ,  KC_R  ,  KC_S  ,  KC_T  ,  KC_D  , KC_ENT ,
-    PW_4  ,  ____  , ST_CTL ,  KC_Z  ,  KC_X  ,  KC_C  ,  KC_V  ,  KC_B  ,  LK_1  ,
-    ____  ,  ____  ,  ____  ,  PW_6  ,  ____  ,  ST_ALT,  ____  ,  ST_GUI,  ____
-);
+                   PW_0  ,  ____  , KC_ESC , KC_F1  ,  KC_F2 ,  KC_F3 ,  KC_F4 ,  KC_F5 , KC_F6  ,
+                   PW_1  ,  ____  , KC_GRV ,  KC_1  ,  KC_2  ,  KC_3  ,  KC_4  ,  KC_5  , KC_DEL ,
+                   PW_2  ,  ____  , KC_TAB ,  KC_Q  ,  KC_W  ,  KC_F  ,  KC_P  ,  KC_G  , KC_BSPC,
+                   PW_3  ,  ____  , ST_SFT ,  KC_A  ,  KC_R  ,  KC_S  ,  KC_T  ,  KC_D  , KC_ENT ,
+                   PW_4  ,  ____  , ST_CTL ,  KC_Z  ,  KC_X  ,  KC_C  ,  KC_V  ,  KC_B  ,  LK_1  ,
+                   ____  ,  ____  ,  ____  ,  PW_6  ,  ____  ,  ST_ALT,  ____  ,  ST_GUI,  ____
+                 );
 
 KEYS(rightKeys) = LAYOUT(
-     KC_F7 , KC_F8  , KC_F9  ,  KC_F10, KC_F11 , KC_F12 , MD_VOLD, MD_PLAY, MD_VOLU ,
-     KC_DEL,  KC_6  ,  KC_7  ,  KC_8  , KC_9   ,  KC_0  , KC_MINS, KC_EQL , PW_5    ,
-    KC_BSPC,  KC_J  ,  KC_L  ,  KC_U  , KC_Y   ,KC_SCLN , KC_LBRC, KC_RBRC, KC_PGUP ,
-     KC_ENT,  KC_H  ,  KC_N  ,  KC_E  , KC_I   ,  KC_O  , KC_QUOT,  ST_SFT, KC_PGDN ,
-     LK_2  ,  KC_K  ,  KC_M  ,KC_COMM , KC_DOT ,KC_SLSH , KC_BSLS,  KC_UP , ST_HYP  ,
-     ____  , KC_SPC ,  ____  ,  ____  , ____   ,  ____  , KC_LEFT, KC_DOWN, KC_RGHT
-);
+                    KC_F7 , KC_F8  , KC_F9  ,  KC_F10, KC_F11 , KC_F12 , MD_VOLD, MD_PLAY, MD_VOLU ,
+                    KC_DEL,  KC_6  ,  KC_7  ,  KC_8  , KC_9   ,  KC_0  , KC_MINS, KC_EQL , PW_5    ,
+                    KC_BSPC,  KC_J  ,  KC_L  ,  KC_U  , KC_Y   , KC_SCLN , KC_LBRC, KC_RBRC, KC_PGUP ,
+                    KC_ENT,  KC_H  ,  KC_N  ,  KC_E  , KC_I   ,  KC_O  , KC_QUOT,  ST_SFT, KC_PGDN ,
+                    LK_2  ,  KC_K  ,  KC_M  , KC_COMM , KC_DOT , KC_SLSH , KC_BSLS,  KC_UP , ST_HYP  ,
+                    ____  , KC_SPC ,  ____  ,  ____  , ____   ,  ____  , KC_LEFT, KC_DOWN, KC_RGHT
+                  );
 
 
 Scanner scanner = Scanner(leftKeys, pinRows, pinCols, ROWS, COLS);
@@ -48,21 +44,21 @@ Password password = Password(PASSWORDS, passwords);
 Receiver receiver = Receiver(rightKeys, ROWS, COLS, DATA, CLK);
 
 void setup() {
-    Wiring::pinMode(_D5, INPUT);
-    Wiring::pinMode(_B0, INPUT);
+  Wiring::pinMode(_D5, INPUT);
+  Wiring::pinMode(_B0, INPUT);
 
-    mechy.add(&keypress);
-    mechy.add(&mediakey);
-    mechy.add(&sticky);
-    mechy.add(&lock);
-    mechy.add(&password);
+  mechy.add(&keypress);
+  mechy.add(&mediakey);
+  mechy.add(&sticky);
+  mechy.add(&lock);
+  mechy.add(&password);
 
-    mechy.attach(&scanner);
-    mechy.attach(&receiver);
+  mechy.attach(&scanner);
+  mechy.attach(&receiver);
 
-    mechy.begin();
+  mechy.begin();
 }
 
 void loop() {
-    mechy.tick();
+  mechy.tick();
 }

--- a/examples/LeftSplit/LeftSplit.ino
+++ b/examples/LeftSplit/LeftSplit.ino
@@ -11,52 +11,54 @@
 #define LK_1 LK
 #define LK_2 LK
 
+// clang-format off
 KEYS(leftKeys) = LAYOUT(
-  PW_0  ,  ____  , KC_ESC , KC_F1  ,  KC_F2 ,  KC_F3 ,  KC_F4 ,  KC_F5 , KC_F6  ,
-  PW_1  ,  ____  , KC_GRV ,  KC_1  ,  KC_2  ,  KC_3  ,  KC_4  ,  KC_5  , KC_DEL ,
-  PW_2  ,  ____  , KC_TAB ,  KC_Q  ,  KC_W  ,  KC_F  ,  KC_P  ,  KC_G  , KC_BSPC,
-  PW_3  ,  ____  , ST_SFT ,  KC_A  ,  KC_R  ,  KC_S  ,  KC_T  ,  KC_D  , KC_ENT ,
-  PW_4  ,  ____  , ST_CTL ,  KC_Z  ,  KC_X  ,  KC_C  ,  KC_V  ,  KC_B  ,  LK_1  ,
-  ____  ,  ____  ,  ____  ,  PW_6  ,  ____  ,  ST_ALT,  ____  ,  ST_GUI,  ____
+    PW_0  ,  ____  , KC_ESC , KC_F1  ,  KC_F2 ,  KC_F3 ,  KC_F4 ,  KC_F5 , KC_F6  ,
+    PW_1  ,  ____  , KC_GRV ,  KC_1  ,  KC_2  ,  KC_3  ,  KC_4  ,  KC_5  , KC_DEL ,
+    PW_2  ,  ____  , KC_TAB ,  KC_Q  ,  KC_W  ,  KC_F  ,  KC_P  ,  KC_G  , KC_BSPC,
+    PW_3  ,  ____  , ST_SFT ,  KC_A  ,  KC_R  ,  KC_S  ,  KC_T  ,  KC_D  , KC_ENT ,
+    PW_4  ,  ____  , ST_CTL ,  KC_Z  ,  KC_X  ,  KC_C  ,  KC_V  ,  KC_B  ,  LK_1  ,
+    ____  ,  ____  ,  ____  ,  PW_6  ,  ____  ,  ST_ALT,  ____  ,  ST_GUI,  ____
 );
 
 KEYS(rightKeys) = LAYOUT(
-  KC_F7 , KC_F8  , KC_F9  ,  KC_F10, KC_F11 , KC_F12 , MD_VOLD, MD_PLAY, MD_VOLU ,
-  KC_DEL,  KC_6  ,  KC_7  ,  KC_8  , KC_9   ,  KC_0  , KC_MINS, KC_EQL , PW_5    ,
-  KC_BSPC,  KC_J  ,  KC_L  ,  KC_U  , KC_Y   , KC_SCLN , KC_LBRC, KC_RBRC, KC_PGUP ,
-  KC_ENT,  KC_H  ,  KC_N  ,  KC_E  , KC_I   ,  KC_O  , KC_QUOT,  ST_SFT, KC_PGDN ,
-  LK_2  ,  KC_K  ,  KC_M  , KC_COMM , KC_DOT , KC_SLSH , KC_BSLS,  KC_UP , ST_HYP  ,
-  ____  , KC_SPC ,  ____  ,  ____  , ____   ,  ____  , KC_LEFT, KC_DOWN, KC_RGHT
+    KC_F7 , KC_F8  , KC_F9  ,  KC_F10, KC_F11 , KC_F12 , MD_VOLD, MD_PLAY, MD_VOLU ,
+    KC_DEL,  KC_6  ,  KC_7  ,  KC_8  , KC_9   ,  KC_0  , KC_MINS, KC_EQL , PW_5    ,
+    KC_BSPC,  KC_J  ,  KC_L  ,  KC_U  , KC_Y   , KC_SCLN , KC_LBRC, KC_RBRC, KC_PGUP ,
+    KC_ENT,  KC_H  ,  KC_N  ,  KC_E  , KC_I   ,  KC_O  , KC_QUOT,  ST_SFT, KC_PGDN ,
+    LK_2  ,  KC_K  ,  KC_M  , KC_COMM , KC_DOT , KC_SLSH , KC_BSLS,  KC_UP , ST_HYP  ,
+    ____  , KC_SPC ,  ____  ,  ____  , ____   ,  ____  , KC_LEFT, KC_DOWN, KC_RGHT
 );
+// clang-format on
 
 Scanner scanner = Scanner(leftKeys, pinRows, pinCols, ROWS, COLS);
-Mechy mechy = Mechy();
+Mechy   mechy   = Mechy();
 
 KeyPress keypress = KeyPress();
 MediaKey mediakey = MediaKey();
-Sticky sticky = Sticky();
-Lock lock = Lock();
+Sticky   sticky   = Sticky();
+Lock     lock     = Lock();
 #define PASSWORDS 7
 const char* passwords[PASSWORDS] = {"", "", "", "", "", "", ""};
-Password password = Password(PASSWORDS, passwords);
-Receiver receiver = Receiver(rightKeys, ROWS, COLS, DATA, CLK);
+Password    password             = Password(PASSWORDS, passwords);
+Receiver    receiver             = Receiver(rightKeys, ROWS, COLS, DATA, CLK);
 
 void setup() {
-  Wiring::pinMode(_D5, INPUT);
-  Wiring::pinMode(_B0, INPUT);
+    Wiring::pinMode(_D5, INPUT);
+    Wiring::pinMode(_B0, INPUT);
 
-  mechy.add(&keypress);
-  mechy.add(&mediakey);
-  mechy.add(&sticky);
-  mechy.add(&lock);
-  mechy.add(&password);
+    mechy.add(&keypress);
+    mechy.add(&mediakey);
+    mechy.add(&sticky);
+    mechy.add(&lock);
+    mechy.add(&password);
 
-  mechy.attach(&scanner);
-  mechy.attach(&receiver);
+    mechy.attach(&scanner);
+    mechy.attach(&receiver);
 
-  mechy.begin();
+    mechy.begin();
 }
 
 void loop() {
-  mechy.tick();
+    mechy.tick();
 }

--- a/examples/Planck/Planck.ino
+++ b/examples/Planck/Planck.ino
@@ -4,42 +4,43 @@
 #include <Mechy/GotoLayer.h>
 #include <Mechy/Hardware/Planck.h>
 
+// clang-format off
 KEYS(mainKeys) = LAYOUT(
-  KC_TAB , KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , KC_BSPC,
-  KC_ESC , KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   , KC_SCLN, KC_QUOT,
-  KC_LSFT, KC_Z   , KC_X   , KC_C   , KC_V   , KC_B   , KC_N   , KC_M   , KC_COMM, KC_DOT , KC_SLSH, KC_ENT ,
-    ____ , KC_LCTL, KC_LALT, KC_LGUI, LOWER  , KC_SPC , KC_SPC , RAISE  , KC_LEFT, KC_DOWN, KC_UP  , KC_RGHT
+    KC_TAB , KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , KC_BSPC,
+    KC_ESC , KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   , KC_SCLN, KC_QUOT,
+    KC_LSFT, KC_Z   , KC_X   , KC_C   , KC_V   , KC_B   , KC_N   , KC_M   , KC_COMM, KC_DOT , KC_SLSH, KC_ENT ,
+      ____ , KC_LCTL, KC_LALT, KC_LGUI, LOWER  , KC_SPC , KC_SPC , RAISE  , KC_LEFT, KC_DOWN, KC_UP  , KC_RGHT
 );
 
 KEYS(lowerKeys) = LAYOUT(
-  KC_TILD, KC_EXLM, KC_AT  , KC_HASH, KC_DLR , KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC ,
-  KC_DEL , KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE ,
-    ____ , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,  ____  ,  ____  , KC_HOME, KC_END ,  ____   ,
-    ____ ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  , MD_NEXT, MD_VOLD, MD_VOLU, MD_PLAY
+    KC_TILD, KC_EXLM, KC_AT  , KC_HASH, KC_DLR , KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC ,
+    KC_DEL , KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE ,
+      ____ , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,  ____  ,  ____  , KC_HOME, KC_END ,  ____   ,
+      ____ ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  , MD_NEXT, MD_VOLD, MD_VOLU, MD_PLAY
 );
 
 KEYS(upperKeys) = LAYOUT(
-  KC_GRV , KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , KC_BSPC ,
-  KC_DEL , KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_MINS, KC_EQL , KC_LBRC, KC_RBRC, KC_BSLS ,
-    ____ , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,  ____  ,  ____  , KC_PGUP, KC_PGDN,  ____   ,
-    ____ ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  , MD_NEXT, MD_VOLD, MD_VOLU, MD_PLAY
+    KC_GRV , KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , KC_BSPC ,
+    KC_DEL , KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_MINS, KC_EQL , KC_LBRC, KC_RBRC, KC_BSLS ,
+      ____ , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,  ____  ,  ____  , KC_PGUP, KC_PGDN,  ____   ,
+      ____ ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  , MD_NEXT, MD_VOLD, MD_VOLU, MD_PLAY
 );
+// clang-format on
 
-
-Layout layout = Layout(ROWS, COLS, mainKeys, lowerKeys, upperKeys);
+Layout  layout  = Layout(ROWS, COLS, mainKeys, lowerKeys, upperKeys);
 Scanner scanner = Scanner(&layout, pinRows, pinCols, ROWS, COLS);
 
-Mechy mechy = Mechy();
+Mechy    mechy    = Mechy();
 Hardware hardware = Hardware(&mechy);
 
 void setup() {
-  mechy.add(new KeyPress());
-  mechy.attach(&scanner);
-  mechy.begin();
-  hardware.begin();
+    mechy.add(new KeyPress());
+    mechy.attach(&scanner);
+    mechy.begin();
+    hardware.begin();
 }
 
 void loop() {
-  mechy.tick();
-  hardware.tick();
+    mechy.tick();
+    hardware.tick();
 }

--- a/examples/Planck/Planck.ino
+++ b/examples/Planck/Planck.ino
@@ -5,24 +5,24 @@
 #include <Mechy/Hardware/Planck.h>
 
 KEYS(mainKeys) = LAYOUT(
-    KC_TAB , KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , KC_BSPC,
-    KC_ESC , KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   , KC_SCLN, KC_QUOT,
-    KC_LSFT, KC_Z   , KC_X   , KC_C   , KC_V   , KC_B   , KC_N   , KC_M   , KC_COMM, KC_DOT , KC_SLSH, KC_ENT ,
-      ____ , KC_LCTL, KC_LALT, KC_LGUI, LOWER  , KC_SPC , KC_SPC , RAISE  , KC_LEFT, KC_DOWN, KC_UP  , KC_RGHT
+  KC_TAB , KC_Q   , KC_W   , KC_E   , KC_R   , KC_T   , KC_Y   , KC_U   , KC_I   , KC_O   , KC_P   , KC_BSPC,
+  KC_ESC , KC_A   , KC_S   , KC_D   , KC_F   , KC_G   , KC_H   , KC_J   , KC_K   , KC_L   , KC_SCLN, KC_QUOT,
+  KC_LSFT, KC_Z   , KC_X   , KC_C   , KC_V   , KC_B   , KC_N   , KC_M   , KC_COMM, KC_DOT , KC_SLSH, KC_ENT ,
+    ____ , KC_LCTL, KC_LALT, KC_LGUI, LOWER  , KC_SPC , KC_SPC , RAISE  , KC_LEFT, KC_DOWN, KC_UP  , KC_RGHT
 );
 
 KEYS(lowerKeys) = LAYOUT(
-    KC_TILD, KC_EXLM, KC_AT  , KC_HASH, KC_DLR , KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC ,
-    KC_DEL , KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE ,
-      ____ , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,  ____  ,  ____  , KC_HOME, KC_END ,  ____   ,
-      ____ ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  , MD_NEXT, MD_VOLD, MD_VOLU, MD_PLAY
+  KC_TILD, KC_EXLM, KC_AT  , KC_HASH, KC_DLR , KC_PERC, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC ,
+  KC_DEL , KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE ,
+    ____ , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,  ____  ,  ____  , KC_HOME, KC_END ,  ____   ,
+    ____ ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  , MD_NEXT, MD_VOLD, MD_VOLU, MD_PLAY
 );
 
 KEYS(upperKeys) = LAYOUT(
-    KC_GRV , KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , KC_BSPC ,
-    KC_DEL , KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_MINS, KC_EQL , KC_LBRC, KC_RBRC, KC_BSLS ,
-      ____ , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,  ____  ,  ____  , KC_PGUP, KC_PGDN,  ____   ,
-      ____ ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  , MD_NEXT, MD_VOLD, MD_VOLU, MD_PLAY
+  KC_GRV , KC_1   , KC_2   , KC_3   , KC_4   , KC_5   , KC_6   , KC_7   , KC_8   , KC_9   , KC_0   , KC_BSPC ,
+  KC_DEL , KC_F1  , KC_F2  , KC_F3  , KC_F4  , KC_F5  , KC_F6  , KC_MINS, KC_EQL , KC_LBRC, KC_RBRC, KC_BSLS ,
+    ____ , KC_F7  , KC_F8  , KC_F9  , KC_F10 , KC_F11 , KC_F12 ,  ____  ,  ____  , KC_PGUP, KC_PGDN,  ____   ,
+    ____ ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  ,  ____  , MD_NEXT, MD_VOLD, MD_VOLU, MD_PLAY
 );
 
 
@@ -33,13 +33,13 @@ Mechy mechy = Mechy();
 Hardware hardware = Hardware(&mechy);
 
 void setup() {
-    mechy.add(new KeyPress());
-    mechy.attach(&scanner);
-    mechy.begin();
-    hardware.begin();
+  mechy.add(new KeyPress());
+  mechy.attach(&scanner);
+  mechy.begin();
+  hardware.begin();
 }
 
 void loop() {
-    mechy.tick();
-    hardware.tick();
+  mechy.tick();
+  hardware.tick();
 }

--- a/examples/RightSplit/RightSplit.ino
+++ b/examples/RightSplit/RightSplit.ino
@@ -6,9 +6,9 @@
 Transmitter transmitter = Transmitter(DATA, CLK, pinRows, pinCols, ROWS, COLS);
 
 void setup() {
-    transmitter.begin();
+  transmitter.begin();
 }
 
 void loop() {
-    transmitter.scan();
+  transmitter.scan();
 }

--- a/examples/RightSplit/RightSplit.ino
+++ b/examples/RightSplit/RightSplit.ino
@@ -1,14 +1,7 @@
 // we don't actually need this header, but the arduino IDE won't compile without it.
 #include <Mechy.h>
 #include <Mechy/Transmitter.h>
-
-#define DATA _D1
-#define CLK _D0
-
-#define ROWS 6
-#define COLS 9
-const uint8_t pinRows[] = { _D3, _D2, _D4, _C6, _D7, _E6};
-const uint8_t pinCols[] = { _B5, _B6, _B2, _B3, _B1, _F7, _F6, _F5, _F4};
+#include <Mechy/Hardware/BFO9000.h>
 
 Transmitter transmitter = Transmitter(DATA, CLK, pinRows, pinCols, ROWS, COLS);
 

--- a/examples/RightSplit/RightSplit.ino
+++ b/examples/RightSplit/RightSplit.ino
@@ -6,9 +6,9 @@
 Transmitter transmitter = Transmitter(DATA, CLK, pinRows, pinCols, ROWS, COLS);
 
 void setup() {
-  transmitter.begin();
+    transmitter.begin();
 }
 
 void loop() {
-  transmitter.scan();
+    transmitter.scan();
 }

--- a/src/Mechy/Hardware/Planck.h
+++ b/src/Mechy/Hardware/Planck.h
@@ -7,8 +7,8 @@ KEYS(keys) = LAYOUT(
 );
 */
 
-#define ROWS 5
-#define COLS 15
+#define ROWS 4
+#define COLS 12
 const uint8_t pinRows[] = { _D0, _D5, _B5, _B6 }
 const uint8_t pinCols[] = { _F1, _F0, _B0, _C7, _F4, _F5, _F6, _F7, _D4, _D6, _B4, _D7 }
 


### PR DESCRIPTION
Left and Right split; both to include BFO9000.h and not define pinRow/pinCols and DATA/CLK again
Planck; ROWS/COLS did not match pinRow/pinCols array lengths